### PR TITLE
Updated default parsers to include all embed parsers; updated tests

### DIFF
--- a/src/html2ans/default.py
+++ b/src/html2ans/default.py
@@ -14,6 +14,16 @@ from html2ans.parsers.image import (
     ImageParser,
 )
 from html2ans.parsers.embeds import (
+    ArcPlayerEmbedParser,
+    DailyMotionEmbedParser,
+    FacebookPostEmbedParser,
+    FacebookVideoEmbedParser,
+    FlickrEmbedParser,
+    IFrameParser,
+    ImgurEmbedParser,
+    InstagramEmbedParser,
+    PollDaddyEmbedParser,
+    RedditEmbedParser,
     SpotifyEmbedParser,
     TumblrEmbedParser,
     TwitterTweetEmbedParser,
@@ -21,12 +31,6 @@ from html2ans.parsers.embeds import (
     VimeoEmbedParser,
     VineEmbedParser,
     YoutubeEmbedParser,
-    FacebookPostEmbedParser,
-    FacebookVideoEmbedParser,
-    IFrameParser,
-    ImgurEmbedParser,
-    InstagramEmbedParser,
-    ArcPlayerEmbedParser,
 )
 from html2ans.parsers.audio import AudioParser
 from html2ans.parsers.raw_html import RawHtmlParser
@@ -39,33 +43,48 @@ class DefaultHtmlAnsParser(BaseHtmlAnsParser):
     """
 
     DEFAULT_PARSERS = [
+        # embed parsers
+        ArcPlayerEmbedParser(),  # div
+        DailyMotionEmbedParser(),  # iframe
+        FacebookPostEmbedParser(),  # iframe (with embed inside)
+        FacebookVideoEmbedParser(),  # iframe (with embed inside)
+        FlickrEmbedParser(),  # a (with image inside)
+        ImgurEmbedParser(),  # blockquote (with embed inside)
+        InstagramEmbedParser(),  # blockquote (with embed inside)
+        PollDaddyEmbedParser(),  # noscript
+        RedditEmbedParser(),  # blockquote (with embed inside)
+        SpotifyEmbedParser(),  # iframe (with embed inside)
+        TumblrEmbedParser(),  # div
+        TwitterTweetEmbedParser(),  # blockquote (with embed inside)
+        TwitterVideoEmbedParser(),  # blockquote (with embed inside)
+        YoutubeEmbedParser(),  # iframe (with embed inside)
+        VimeoEmbedParser(),  # iframe (with embed inside)
+        VineEmbedParser(),  # iframe (with embed inside)
+
+        # text parsers
         HeaderParser(),  # h1-h6
         ListParser(),  # ul/ol
         FormattedTextParser(),  # strong, em, etc.
-        LinkedImageParser(),  # a
-        LinkParser(),  # a
-        ImageParser(),  # img
-        ArcPlayerEmbedParser(),  # div
-        TumblrEmbedParser(),  # div
-        FigureParser(),  # figure
-        AudioParser(),  # audio
-        TwitterTweetEmbedParser(),  # blockquote (with embed inside)
-        TwitterVideoEmbedParser(),  # blockquote (with embed inside)
-        InstagramEmbedParser(),  # blockquote (with embed inside)
-        ImgurEmbedParser(),  # blockquote (with embed inside)
-        YoutubeEmbedParser(),  # iframe (with embed inside)
-        FacebookPostEmbedParser(),  # iframe (with embed inside)
-        FacebookVideoEmbedParser(),  # iframe (with embed inside)
-        SpotifyEmbedParser(),  # iframe (with embed inside)
-        VimeoEmbedParser(),  # iframe (with embed inside)
-        VineEmbedParser(),  # iframe (with embed inside)
         BlockquoteParser(),  # blockquote
         ParagraphParser(),  # NavigableString, p
-        IFrameParser(),  # iframe
+
+        # image/figure parsers
+        LinkedImageParser(),  # a
+        ImageParser(),  # img
+        FigureParser(),  # figure
+
+        LinkParser(),  # a
+
+        AudioParser(),  # audio
+
+        IFrameParser(),  # generic iframe
+
         NullParser(),  # comments
     ]
     """
-    Default parsers for the default implementation.
+    Default parsers for the default implementation. These will be added to
+    the `BaseHtmlAnsParser` ``parsers`` attribute in the order listed, so
+    order matters!
     """
 
     BACKUP_PARSERS = [
@@ -73,7 +92,8 @@ class DefaultHtmlAnsParser(BaseHtmlAnsParser):
         RawHtmlParser()
     ]
     """
-    Backup parsers for the default implementation.
+    Backup parsers for the default implementation. These will be tried in
+    the order listed, so order matters!
     """
 
     def __init__(self, *args, **kwargs):

--- a/src/html2ans/parsers/base.py
+++ b/src/html2ans/parsers/base.py
@@ -13,7 +13,7 @@ class ParseResult(namedtuple('ParseResult', ['output', 'match'])):
     ``output`` is the ANS JSON parsed by the parser.
 
     ``match`` indicates whether or not other parse attempts should be made.
-    
+
     The idea of the parsing "match" is necessary so that we can try
     multiple parsers per tag (and not try multiple parsers when we don't have to).
     For example, when parsing ``<p></p>``, if we only returned an empty dictionary

--- a/src/html2ans/parsers/utils.py
+++ b/src/html2ans/parsers/utils.py
@@ -39,7 +39,7 @@ class AbstractParserUtilities(object):
 
     EMPTY_STRINGS = [None, '', ' ', '\n', '<br>', '<br/>']
     """
-    List of strings considered empty (if a ``NavigableString`` is passed to 
+    List of strings considered empty (if a ``NavigableString`` is passed to
     ``is_empty`` and the string is in this list, ``is_empty`` will return True).
     """
 

--- a/tests/test_html2ans.py
+++ b/tests/test_html2ans.py
@@ -21,14 +21,24 @@ def test_empty(body_html, test_html2ans):
     "<body><!-- test comment 4 --></body>",
     '<body><div><p><!-- <a href="#test">test link</a> --></p></div></body>'
     '<body><p><!-- uuid: \"002051cc-8f7a-11e8-9774-c7a7ea8e16e4\"--></p></body>',
-    "<body><!-- <div><p>Commented out</p></div> --></body>"
-    ])
+    "<body><!-- <div><p>Commented out</p></div> --></body>",
+    "<!-- test comment 1 --><div><!-- test comment 2 --></div>",
+    "<div><p><!-- test comment 3 --></p></div>",
+    "<!-- test comment 4 -->",
+    '<div><p><!-- <a href="#test">test link</a> --></p></div>'
+    '<p><!-- uuid: \"002051cc-8f7a-11e8-9774-c7a7ea8e16e4\"--></p>',
+    "<!-- <div><p>Commented out</p></div> -->"
+])
 def test_comments(test_html, test_html2ans):
     assert test_html2ans.generate_ans(test_html) == []
 
 
-def test_empty_except_navigable_string(test_html2ans):
-    parsed = test_html2ans.generate_ans('<body>This is a navigable string</body>')
+@pytest.mark.parametrize('test_html', [
+    '<body>This is a navigable string</body>',
+    'This is a navigable string',
+])
+def test_empty_except_navigable_string(test_html, test_html2ans):
+    parsed = test_html2ans.generate_ans(test_html)
     assert len(parsed) == 1
     assert parsed[0].get('content') == 'This is a navigable string'
 


### PR DESCRIPTION
## Description (a few sentences describing the overall goals of the PR's commits)
Recently added embed parsers were not being added to `DefaultHtmlAnsParser` as default parsers. This PR adds those parsers to the defaults, adds some comments, addresses a couple of minor style issues, and adds some additional tests to `test_html2ans`.

## Steps to Test or Reproduce (outline the steps to test or reproduce the PR here)
Parse a PollDaddy, Reddit, Flickr, etc. embed using the `DefaultHtmlAnsParser`/`Html2Ans` class and ensure that it comes back as an `oembed` rather than `raw_html`.

## Todos
Before PR:
- [ ] Add tests
- [x] Add documentation

## Comments (include any comments to help with an effective code review here)

