### PR TITLE
Removed pypirc file creation; we can use twine environment variables …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,6 @@ jobs: # A basic unit of work in a run
     steps:
       - checkout
       - run:
-          name: init .pypirc
-          command: |
-            echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = arcpsteam" >> ~/.pypirc
-            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
-      - run:
           name: Build and deploy
           command: |
             python3 -m virtualenv html2ans


### PR DESCRIPTION
…instead

## Description (a few sentences describing the overall goals of the PR's commits)
This project uses twine to upload its package to pypi. [Twine can use environment variables for this upload](https://twine.readthedocs.io/en/latest/#environment-variables), so there's no need to create a pypirc file.

## Steps to Test or Reproduce (outline the steps to test or reproduce the PR here)

## Todos
Before PR:
- [ ] Add tests
- [ ] Add documentation


## Comments (include any comments to help with an effective code review here)
The circleci build's environment variables will need to be updated per the Twine documentation.
