### PR TITLE
Improved List Parsing

### DIFF
--- a/docs/parsers/text_parser.rst
+++ b/docs/parsers/text_parser.rst
@@ -34,7 +34,7 @@ Header Parser
 Link Parser
 -----------
 
-.. autoclass:: html2ans.parsers.text.LinkParser
+.. autoclass:: html2ans.parsers.text.InterstitialLinkParser
 
 
 List Parser

--- a/src/html2ans/default.py
+++ b/src/html2ans/default.py
@@ -1,7 +1,7 @@
 from html2ans.base import BaseHtmlAnsParser
 from html2ans.parsers.base import NullParser
 from html2ans.parsers.text import (
-    LinkParser,
+    InterstitialLinkParser,
     BlockquoteParser,
     FormattedTextParser,
     HeaderParser,
@@ -73,7 +73,7 @@ class DefaultHtmlAnsParser(BaseHtmlAnsParser):
         ImageParser(),  # img
         FigureParser(),  # figure
 
-        LinkParser(),  # a
+        InterstitialLinkParser(),  # a
 
         AudioParser(),  # audio
 

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -317,22 +317,36 @@ class ListParser(BaseElementParser):
             'type': 'list',
             'list_type': 'unordered',
             'items': [
-                {'type': 'text',
-                 'content': 'Post Reports is the daily'},
-                {'type': 'text',
-                 'content': '<a href="/podcast/">podcast</a>'},
-                {'type': 'text',
-                 'content': 'from The Washington Post.'},
-                {'type': 'list',
-                 'list_type': 'unordered',
-                 'items': [
-                     {'type': 'text',
-                      'content': 'Unparalleled reporting.'},
-                     {'type': 'text',
-                      'content': 'Expert insight.'}
-                 ]
+                {
+                    'type': 'text',
+                    'content': 'Post Reports is the daily'
                 },
-                {'type': 'text', 'content': 'Clear analysis.'}
+                {
+                    'type': 'text',
+                    'content': '<a href="/podcast/">podcast</a>'
+                },
+                {
+                    'type': 'text',
+                    'content': 'from The Washington Post.'
+                },
+                {
+                    'type': 'list',
+                    'list_type': 'unordered',
+                    'items': [
+                        {
+                            'type': 'text',
+                            'content': 'Unparalleled reporting.'
+                        },
+                        {
+                            'type': 'text',
+                            'content': 'Expert insight.'
+                        }
+                    ]
+                },
+                {
+                    'type': 'text',
+                    'content': 'Clear analysis.'
+                }
             ]
         }
 

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -382,3 +382,7 @@ class ListParser(BaseElementParser):
         result["list_type"] = list_type
         result["items"] = list_elements
         return ParseResult(result, True)
+
+
+# Backwards compatibility
+LinkParser = InterstitialLinkParser

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -15,7 +15,7 @@ class AbstractTextParser(BaseElementParser):
     def construct_output(self, element, *args, **kwargs):
         if isinstance(element, NavigableString) or isinstance(element, six.text_type):
             content = six.text_type(element).strip()
-        elif element.name == "a":
+        elif element.name in self.STYLING_TAGS:
             content = str(element)
         else:
             # There doesn't seem to be a great way to extract the text
@@ -107,10 +107,6 @@ class FormattedTextParser(AbstractTextParser):
         if self.is_text_only(element):
             match = True
             result = self.construct_output(element)
-            if isinstance(result, dict):
-                result["content"] = "<{}>{}</{}>".format(
-                    element.name,
-                    result.get("content"), element.name)
         return ParseResult(result, match)
 
 

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -246,7 +246,7 @@ class LinkParser(BaseElementParser):
     applicable_elements = ['a']
 
     def parse(self, element, *args, **kwargs):
-        result = self.construct_output(element, "interstitial_link", str(element))
+        result = self.construct_output(element, "interstitial_link", element.text)
         match = True
         url = element.attrs.get('href')
         result["url"] = url

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -344,9 +344,9 @@ class ListParser(BaseElementParser):
 
 
     """
+    applicable_elements = ['ul', 'ol']
 
     def __init__(self, list_item_parser=None):
-        self.applicable_elements = ['ul', 'ol']
         self.text_parser = list_item_parser if list_item_parser else ListItemParser()
 
     def parse(self, element, *args, **kwargs):

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -347,7 +347,7 @@ class ListParser(BaseElementParser):
     applicable_elements = ['ul', 'ol']
 
     def __init__(self, list_item_parser=None):
-        self.text_parser = list_item_parser if list_item_parser else ListItemParser()
+        self.list_item_parser = list_item_parser if list_item_parser else ListItemParser()
 
     def parse(self, element, *args, **kwargs):
         list_elements = []
@@ -376,8 +376,8 @@ class ListParser(BaseElementParser):
 
                 else:
 
-                    if self.text_parser.is_applicable(list_item):
-                        _add_list_element(self.text_parser.parse(list_item).output, "content")
+                    if self.list_item_parser.is_applicable(list_item):
+                        _add_list_element(self.list_item_parser.parse(list_item).output, "content")
 
         result = self.construct_output(element, "list")
         result["list_type"] = list_type

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -306,7 +306,7 @@ class ListParser(BaseElementParser):
                     <li>Unparalleled reporting.</li>
                     <li>Expert insight.</li>
                 </ol>
-            <li>Clear analysis.</li>
+            <li><p>Clear analysis.</p></li>
         </ul>
 
     ->
@@ -337,7 +337,7 @@ class ListParser(BaseElementParser):
                 },
                 {
                     'type': 'text',
-                    'content': 'Clear analysis.'
+                    'content': '<p>Clear analysis.</p>'
                 }
             ]
         }

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -296,12 +296,16 @@ class ListParser(BaseElementParser):
     .. code-block:: html
 
         <ul>
-            <li>Post Reports, <a href="/podcast/">a daily podcast</a> from The Washington Post.</li>
             <li>
-                <ul>
+                Post Reports,
+                <a href="/podcast/">a daily podcast</a>
+                from The Washington Post.
+            </li>
+            <li>
+                <ol>
                     <li>Unparalleled reporting.</li>
                     <li>Expert insight.</li>
-                </ul>
+                </ol>
             <li>Clear analysis.</li>
         </ul>
 
@@ -319,7 +323,7 @@ class ListParser(BaseElementParser):
                 },
                 {
                     'type': 'list',
-                    'list_type': 'unordered',
+                    'list_type': 'ordered',
                     'items': [
                         {
                             'type': 'text',

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -344,8 +344,10 @@ class ListParser(BaseElementParser):
 
 
     """
-    applicable_elements = ['ul', 'ol']
-    text_parser = ListItemParser
+
+    def __init__(self, list_item_parser=None):
+        self.applicable_elements = ['ul', 'ol']
+        self.text_parser = list_item_parser if list_item_parser else ListItemParser()
 
     def parse(self, element, *args, **kwargs):
         list_elements = []
@@ -374,8 +376,8 @@ class ListParser(BaseElementParser):
 
                 else:
 
-                    if self.text_parser().is_applicable(list_item):
-                        _add_list_element(self.text_parser().parse(list_item).output, "content")
+                    if self.text_parser.is_applicable(list_item):
+                        _add_list_element(self.text_parser.parse(list_item).output, "content")
 
         result = self.construct_output(element, "list")
         result["list_type"] = list_type

--- a/src/html2ans/parsers/utils.py
+++ b/src/html2ans/parsers/utils.py
@@ -48,7 +48,7 @@ class AbstractParserUtilities(object):
     List of tags considered empty (if a tag passed to ``is_empty`` is in this list,
     ``is_empty`` will return True).
     """
-    STYLING_TAGS = [
+    INLINE_TAGS = [
         'a',
         'b',
         'del',
@@ -63,7 +63,7 @@ class AbstractParserUtilities(object):
         'span'
     ]
 
-    TEXT_TAGS = STYLING_TAGS + ['p', 'blockquote']
+    TEXT_TAGS = INLINE_TAGS + ['p', 'blockquote']
     """
     List of tags considered to be text. This affects the results of ``is_text_only``
     which is used by most text parsers. For example, because by default ``a`` tags

--- a/src/html2ans/parsers/utils.py
+++ b/src/html2ans/parsers/utils.py
@@ -48,10 +48,7 @@ class AbstractParserUtilities(object):
     List of tags considered empty (if a tag passed to ``is_empty`` is in this list,
     ``is_empty`` will return True).
     """
-
-    TEXT_TAGS = [
-        'blockquote',
-        'p',
+    STYLING_TAGS = [
         'a',
         'b',
         'del',
@@ -63,7 +60,10 @@ class AbstractParserUtilities(object):
         'strong',
         'sub',
         'sup',
-        'span']
+        'span'
+    ]
+
+    TEXT_TAGS = STYLING_TAGS + ['p', 'blockquote']
     """
     List of tags considered to be text. This affects the results of ``is_text_only``
     which is used by most text parsers. For example, because by default ``a`` tags

--- a/tests/parsers/test_text_link.py
+++ b/tests/parsers/test_text_link.py
@@ -1,7 +1,7 @@
 import pytest
-from html2ans.parsers.text import LinkParser
+from html2ans.parsers.text import InterstitialLinkParser
 
-parser = LinkParser()
+parser = InterstitialLinkParser()
 
 
 @pytest.mark.parametrize('tag_string', [

--- a/tests/parsers/test_text_list.py
+++ b/tests/parsers/test_text_list.py
@@ -1,4 +1,5 @@
 import pytest
+
 from html2ans.parsers.text import ListParser
 
 parser = ListParser()
@@ -51,19 +52,30 @@ def test_nested_list(make_tag):
     ]
 
 
-def test_link_in_list(make_tag):
-    tag = make_tag('<ul><li><a href="http://www.rcinet.ca">Canada article</a></li></ul>', 'ul')
+def test_complex_list(make_tag):
+    tag = make_tag('<ul><li>Post Reports is the daily <a href="/podcast/">podcast</a> from '
+                   'The Washington Post.</li><li><ul><li>Unparalleled reporting.</li>'
+                   '<li>Expert insight.</li></ul><li>Clear analysis.</li></ul>', 'ul')
     parsed = parser.parse(tag).output
     assert parsed.get('type') == 'list'
     assert parsed.get('list_type') == 'unordered'
     assert parsed.get('items') == [
-        {
-            'type': 'text',
-            'content': 'Canada article',
-            'additional_properties': {
-                'href': "http://www.rcinet.ca"
-            }
-        }
+        {'type': 'text',
+         'content': 'Post Reports is the daily'},
+        {'type': 'text',
+         'content': '<a href="/podcast/">podcast</a>'},
+        {'type': 'text',
+         'content': 'from The Washington Post.'},
+        {'type': 'list',
+         'list_type': 'unordered',
+         'items': [
+             {'type': 'text',
+              'content': 'Unparalleled reporting.'},
+             {'type': 'text',
+              'content': 'Expert insight.'}
+         ]
+         },
+        {'type': 'text', 'content': 'Clear analysis.'}
     ]
 
 

--- a/tests/parsers/test_text_list.py
+++ b/tests/parsers/test_text_list.py
@@ -38,7 +38,7 @@ def test_nested_list(make_tag):
         {
             'items': [
                 {
-                    'content': 'level two item',
+                    'content': '<p>level two item</p>',
                     'type': 'text'
                 }
             ],
@@ -46,42 +46,33 @@ def test_nested_list(make_tag):
             'type': 'list'
         },
         {
-            'content': 'level one item',
+            'content': '<p>level one item</p>',
             'type': 'text'
         }
     ]
 
 
 def test_complex_list(make_tag):
-    tag = make_tag('<ul><li>Post Reports is the daily '
-                   '<a class="pod_link" href="/podcast/">podcast</a> from '
-                   'The Washington Post.</li><li><ul><li>Unparalleled reporting.</li>'
-                   '<li>Expert insight.</li></ul><li>Clear analysis.</li></ul>', 'ul')
+    tag = make_tag('<ul><li>Post Reports, '
+                   '<a href="/podcast/">a daily podcast</a> '
+                   'from The Washington Post.</li>'
+                   '<li><ol><li>Unparalleled reporting.</li>'
+                   '<li>Expert insight.</li></ol>'
+                   '<li>Clear analysis.</li></ul>', 'ul')
     parsed = parser.parse(tag).output
     assert parsed.get('type') == 'list'
     assert parsed.get('list_type') == 'unordered'
-    assert parsed.get('items') == [
-        {'type': 'text',
-         'content': 'Post Reports is the daily'},
-        {'type': 'text',
-         'content': '<a class="pod_link" href="/podcast/">podcast</a>',
-         'additional_properties': {
-             'class': ['pod_link'],
-             'href': '/podcast/'
-         }},
-        {'type': 'text',
-         'content': 'from The Washington Post.'},
-        {'type': 'list',
-         'list_type': 'unordered',
-         'items': [
-             {'type': 'text',
-              'content': 'Unparalleled reporting.'},
-             {'type': 'text',
-              'content': 'Expert insight.'}
-         ]
-         },
-        {'type': 'text', 'content': 'Clear analysis.'}
-    ]
+    list_items = parsed.get("items")
+    assert len(list_items) == 3
+    assert list_items[0].get("type") == "text"
+    assert list_items[0].get("content") == 'Post Reports, ' \
+                                           '<a href="/podcast/">a daily podcast</a> ' \
+                                           'from The Washington Post.'
+    assert list_items[1].get("type") == "list"
+    assert list_items[1].get("list_type") == "ordered"
+    assert len(list_items[1].get("items")) == 2
+    assert list_items[1].get("items")[0].get("type") == "text"
+    assert list_items[2].get("type") == "text"
 
 
 def test_basic_list(make_tag):

--- a/tests/parsers/test_text_list.py
+++ b/tests/parsers/test_text_list.py
@@ -53,7 +53,8 @@ def test_nested_list(make_tag):
 
 
 def test_complex_list(make_tag):
-    tag = make_tag('<ul><li>Post Reports is the daily <a href="/podcast/">podcast</a> from '
+    tag = make_tag('<ul><li>Post Reports is the daily '
+                   '<a class="pod_link" href="/podcast/">podcast</a> from '
                    'The Washington Post.</li><li><ul><li>Unparalleled reporting.</li>'
                    '<li>Expert insight.</li></ul><li>Clear analysis.</li></ul>', 'ul')
     parsed = parser.parse(tag).output
@@ -63,7 +64,11 @@ def test_complex_list(make_tag):
         {'type': 'text',
          'content': 'Post Reports is the daily'},
         {'type': 'text',
-         'content': '<a href="/podcast/">podcast</a>'},
+         'content': '<a class="pod_link" href="/podcast/">podcast</a>',
+         'additional_properties': {
+             'class': ['pod_link'],
+             'href': '/podcast/'
+         }},
         {'type': 'text',
          'content': 'from The Washington Post.'},
         {'type': 'list',


### PR DESCRIPTION
## Description (a few sentences describing the overall goals of the PR's commits)
Parse inline links in list items as inline text elements.  handle list item tags with multiple text contents, such as text before and or after an inline link. make list of text parsers extensible.

## Steps to Test or Reproduce (outline the steps to test or reproduce the PR here)
added unit test with more complex test case including a link

## Comments (include any comments to help with an effective code review here)
I added a new InlineLinkParser, and would like an opinion on if it should be part of the default parsers list or not... it is not currently.
