### PR TITLE
Docs and packaging update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs: # A basic unit of work in a run
       - run: mkdir test-reports
       - run:
           name: Run tests
-          command: tox -e circleci
+          command: tox -e py27-circleci, py35-circleci, py36-circleci, py37-circleci
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: test-reports
       - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,8 @@ parsers ``Html2Ans`` will use like so:
     parser.generate_ans(your_html_here)
 
 
+The types of items your parser can parse should be listed in its ``applicable_elements`` attribute.
+
 The default parser class (``DefaultHtmlAnsParser`` or ``Html2Ans``) has parsers for text, links, images, various social media embeds, etc.
 
 
@@ -90,7 +92,7 @@ The default image parser ``html2ans.parsers.image.ImageParser`` applies to html 
     from html2ans.parsers.base import ParseResult
 
     class YourCustomImageParser(ImageParser):
-        applicable_elements = ['div']
+        applicable_elements = ['div', 'figure']
         applicable_classes = ['fancy-figure']
 
         def parse(self, element, *args, **kwargs):
@@ -102,3 +104,38 @@ The default image parser ``html2ans.parsers.image.ImageParser`` applies to html 
                   image["caption"] = caption_tag.text
                 return ParseResult(image, True)
             return ParseResult(None, True)
+
+
+Custom Parsing Tips
+~~~~~~~~~~~~~~~~~~~
+
+ANS Versions
+^^^^^^^^^^^^
+
+Some ANS types require a version. You can set a version in your main parser (``Html2Ans``) and then automatically include that version in any element parser's output by setting the parser's ``version_required`` attribute to ``True``.
+
+*Note: this doesn't mean valid, version-compatible ANS is automatically produced!*
+
+
+Keeping HTML in ``text`` Output
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To adjust what HTML is/isn't left inline when parsing text, adjust the ``INLINE_TAGS`` attribute on the text parser. Every parser inherits from ``html2ans.parsers.utils.AbstractParserUtilities`` which provides a list of default ``INLINE_TAGS`` which can be used to make sure text formatters (e.g. ``strong``, ``em``, etc.) are left in place when text is parsed.
+
+
+Link Parsing
+^^^^^^^^^^^^
+
+By default, ``a`` tags are left inline in text, assuming there is text outside of the link. A link by itself (e.g. ``<p><a href="google.com">Search</a></p>``) will be turned into an ``interstitial_link``. If ``interstitial_link`` elements are unwanted, simply add ``a`` to the list of ``applicable_elements`` for the ``ParagraphParser``.
+
+
+Removing Unnecessary Tags
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes it is helpful to remove unnecessary tags (e.g. ``<p></p>``, ``<div><img src="..." /></div>``). By default, ``Html2Ans`` considers ``p`` and ``div`` tags with no attributes other than ``id``, ``class``, or ``style`` to be unnecessary "wrappers". When these are encountered, they are ignored and their children are parsed.
+
+The benefit of this is that ``<p></p>`` is ignored and ``<div><img src="..." /></div>`` is parsed as an image.
+
+The downside is that sometimes you don't want your HTML removed! There are a few options in this case. You can configure what tags can be considered wrappers via the ``WRAPPER_TAGS`` attribute on ``Html2Ans``. So if ``div`` tags should never be removed, simply remove ``div`` from this list. If a more complicated set of rules are necessary, override the ``is_wrapper`` method on ``Html2Ans``.
+
+If it's easier to modify the HTML than to modify this library, you can also add an arbitrary attribute like so: ``<div no_parse_flag="true">...</div>``. This ``div`` will not be considered a wrapper when it is encountered.

--- a/docs/parsers/text_parser.rst
+++ b/docs/parsers/text_parser.rst
@@ -31,10 +31,16 @@ Header Parser
 .. autoclass:: html2ans.parsers.text.HeaderParser
 
 
-Link Parser
------------
+Interstitial Link Parser
+------------------------
 
 .. autoclass:: html2ans.parsers.text.InterstitialLinkParser
+
+
+List Item Parser
+----------------
+
+.. autoclass:: html2ans.parsers.text.ListItemParser
 
 
 List Parser

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
     description='Convert HTML to ANS',
     long_description=LONG_DESCRIPTION,

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -257,8 +257,10 @@ class InterstitialLinkParser(BaseElementParser):
 class ListItemParser(ParagraphParser):
     """
     Parses a single list item tag as paragraph text
-    ANS elements of type ``text``. `ANS schema
-    <https://github.com/washingtonpost/ans-schema/blob/master/src/main/resources/schema/ans/0.8.0/story_elements/text.json>`_
+    ANS elements of type ``text``. As of ANS 0.6.2, list items have
+    to be either text or another list (in the case of another list,
+    the ``ListParser`` is used recursively). `ANS schema
+    <https://github.com/washingtonpost/ans-schema/blob/master/src/main/resources/schema/ans/0.8.0/story_elements/list_element.json>`_
 
     Example:
 
@@ -342,6 +344,8 @@ class ListParser(BaseElementParser):
             ]
         }
 
+    :param list_item_parser: the parser to use on individual list elements (defaults to ``ListItemParser``)
+    :type list_item_parser: ElementParser
 
     """
     applicable_elements = ['ul', 'ol']
@@ -363,9 +367,6 @@ class ListParser(BaseElementParser):
             list_type = 'ordered'
 
         for list_item in element.contents:
-
-            # as of ANS 0.6.2, has to be either text or another list
-            # https://github.com/washingtonpost/ans-schema/blob/master/src/main/resources/schema/ans/0.6.2/story_elements/list_element.json
             if isinstance(list_item, Tag) and list_item.contents:
                 child_lists = list_item.find_all(self.applicable_elements)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,35,36}
+envlist=py{27,35,36,37}
 skipsdist=True
 
 [base]
@@ -11,7 +11,7 @@ commands=
 extras=
   tests
 
-[testenv:circleci]
+[circleci]
 commands=
   {[base]commands}
   pytest --junit-xml=test-reports/junit.xml --cov-report=html:test-reports/coverage.html --cov=src
@@ -19,6 +19,41 @@ deps=
   {[base]deps}
 extras=
   {[base]extras}
+
+[testenv:py27-circleci]
+commands=
+  {[circleci]commands}
+deps=
+  {[circleci]deps}
+extras=
+  {[circleci]extras}
+usedevelop=True
+
+[testenv:py35-circleci]
+commands=
+  {[circleci]commands}
+deps=
+  {[circleci]deps}
+extras=
+  {[circleci]extras}
+usedevelop=True
+
+[testenv:py36-circleci]
+commands=
+  {[circleci]commands}
+deps=
+  {[circleci]deps}
+extras=
+  {[circleci]extras}
+usedevelop=True
+
+[testenv:py37-circleci]
+commands=
+  {[circleci]commands}
+deps=
+  {[circleci]deps}
+extras=
+  {[circleci]extras}
 usedevelop=True
 
 [testenv]


### PR DESCRIPTION
## Description (a few sentences describing the overall goals of the PR's commits)
The only functional change here is adding imports to the `__init__` files for easier importing from the package. I also
- Added a "custom parsing tips" section to the readme/quickstart
- Made other minor documentation updates
- Added Python 3.7 to the supported versions

## Steps to Test or Reproduce (outline the steps to test or reproduce the PR here)
The only thing to test is the import update. If you install this package with the `-e` option locally, make sure you can import items from `html2ans` without specifying the full path.

## Todos
Before PR:
- [ ] Add tests
- [x] Add documentation


## Comments (include any comments to help with an effective code review here)

