### PR TITLE
Audio stream url encoding fix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+v3.0.3
+------
+
+* Fixes audio tag parsing ensuring the stream -> url is properly url encoded against bad characters.  This also introduces an external dependency on furl to properly support url encoding across python versions.
+
+
 v3.0.2
 ------
 
@@ -11,7 +18,7 @@ v3.0.1
 ------
 
 * Adds ``DailyMotionEmbedParser``, ``FlickrEmbedParser``, ``PollDaddyEmbedParser``, and ``RedditEmbedParser`` to ``DEFAULT_PARSERS`` in ``Html2Ans``/``DefaultHtmlAnsParser``
-  
+
   - These were accidentally left out of ``DEFAULT_PARSERS`` in v3.0.0
 
 * Updates the ``InstagramEmbedParser`` to accept hyphens in embed IDs

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ INSTALL_REQUIRES = (
     'html5lib<2',
     'lxml<5',
     'six<2',
+    'furl>=2.0.0',
 )
 TESTS_REQUIRE = ('pytest<5',)
 SETUP_REQUIRES = (('pytest-runner',) if NEEDS_PYTEST else ()) + (DOCS_REQUIRE if NEEDS_DOCS else ())
@@ -29,7 +30,7 @@ with open(os.path.join(THIS_FILE_DIR, 'README.rst'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
 # The full version, including alpha/beta/rc tags
-RELEASE = '3.0.2'
+RELEASE = '3.0.3'
 # The short X.Y version
 VERSION = '.'.join(RELEASE.split('.')[:2])
 

--- a/src/html2ans/parsers/audio.py
+++ b/src/html2ans/parsers/audio.py
@@ -37,8 +37,8 @@ class AudioParser(BaseElementParser):
             if source_url:
                 result = self.construct_output(element, "audio")
                 result["streams"] = [{
-                    # escapes white space in the URL
-                    "url": source_url
+                    # url encodes any illegal url characters
+                    "url": self._create_encoded_url(source_url)
                 }]
                 match = True
         return ParseResult(result, match)

--- a/src/html2ans/parsers/utils.py
+++ b/src/html2ans/parsers/utils.py
@@ -1,6 +1,7 @@
 import six
 
 from bs4.element import NavigableString, Tag
+from furl import furl
 
 
 def has_attributes(tag, filter_types=('id', 'class', 'style')):
@@ -152,3 +153,13 @@ class AbstractParserUtilities(object):
                     elif not [isinstance(child, filter_type) for filter_type in filter_types]:
                         result.append(child)
         return result
+
+    def _create_encoded_url(self, original_url):
+        """
+        Url encode path a uri.
+
+        :param original_url: str URI value
+        :return: URI value properly url encoded to include in ans
+        """
+
+        return furl(original_url).url

--- a/tests/parsers/test_audio.py
+++ b/tests/parsers/test_audio.py
@@ -28,3 +28,16 @@ def test_audio(parser, make_tag):
     parsed = parser.parse(tag)[0]
     assert parsed.get('streams')[0]["url"] == 'audiosource'
     assert parsed.get('type') == 'audio'
+
+
+def test_audio_with_spaces_in_src(parser, make_tag):
+    tag = make_tag('<audio id="asset-1234" class="audio-player" controls="controls">'
+                   '<source src="http://example.com/audio/name with spaces.mp3" type="audio/mpeg">'
+                   '</audio>',
+                   'audio')
+    parsed = parser.parse(tag)[0]
+    assert parsed.get('type') == 'audio'
+    assert parsed.get("additional_properties", {}).get("class") == ["audio-player"]
+    assert parsed.get("additional_properties", {}).get("controls") == "controls"
+    assert parsed.get("additional_properties", {}).get("id") == "asset-1234"
+    assert parsed.get('streams')[0]["url"] == "http://example.com/audio/name%20with%20spaces.mp3"


### PR DESCRIPTION
## Description (a few sentences describing the overall goals of the PR's commits)
fix parsed audio streams url to be properly url encoded.  adds a new utility function for doing this where ever else may be needed.  introduces a dependency on furl as a trade off to supporting multiple python versions

## Steps to Test or Reproduce (outline the steps to test or reproduce the PR here)


## Todos
Before PR:
- [ ] Add tests
- [ ] Add documentation


## Comments (include any comments to help with an effective code review here)

