### PR TITLE
fixes error when embeds were improperly formatted and contained &nbsp;

### DIFF
--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -187,8 +187,6 @@ class BlockquoteParser(AbstractTextParser):
                 p_result = ParagraphParser().parse(element)
                 if p_result.match and p_result.output:
                     content_elements.append(p_result.output)
-                if p_result.match:
-                    content_elements.append(p_result.output)
         content_elements = [el for el in content_elements if el is not None]
         if match and content_elements:
             result = {

--- a/src/html2ans/parsers/text.py
+++ b/src/html2ans/parsers/text.py
@@ -185,9 +185,12 @@ class BlockquoteParser(AbstractTextParser):
                             content_elements.append(p_result.output)
             else:
                 p_result = ParagraphParser().parse(element)
+                if p_result.match and p_result.output:
+                    content_elements.append(p_result.output)
                 if p_result.match:
                     content_elements.append(p_result.output)
-        if match:
+        content_elements = [el for el in content_elements if el is not None]
+        if match and content_elements:
             result = {
                 "type": "quote",
                 "content_elements": content_elements

--- a/tests/parsers/test_text_blockquote.py
+++ b/tests/parsers/test_text_blockquote.py
@@ -20,14 +20,15 @@ def test_is_applicable(parser, valid_quote_tag, make_tag):
     assert parser.is_applicable(make_tag(valid_quote_tag, 'blockquote'))
 
 
-@pytest.mark.parametrize('html', [
-    '<blockquote><p>This is a blockquote.</p></blockquote>',
-    '<blockquote class="something"><p>This is a blockquote.</p></blockquote>',
-    '<blockquote>This is a blockquote.</blockquote>'
+@pytest.mark.parametrize('html,length', [
+    ('<blockquote><p>This is a blockquote.</p></blockquote>', 1),
+    ('<blockquote class="something"><p>This is a blockquote.</p></blockquote>', 1),
+    ('<blockquote>This is a blockquote.</blockquote>', 1),
 ])
-def test_blockquote_with_p(html, parser, make_tag):
+def test_blockquote_with_p(html, length, parser, make_tag):
     tag = make_tag(html, 'blockquote')
     parsed = parser.parse(tag).output
+    assert len(parsed.get('content_elements')) == length
     assert parsed.get('content_elements')[0]["content"] == 'This is a blockquote.'
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -56,6 +56,27 @@ def test_start_tag(test_html2ans):
     assert test_html2ans.generate_ans('<body><p></p></body>', start_tag='blockquote') == []
 
 
+"""
+    These instances were returning a content element of 
+    {
+        "type": "quote",
+        "content_elements": [None]
+    }
+    which is not valid ans.  The reason was due to the way these fell back to
+    the blockquote parser when the initial parsers failed.
+"""
+@pytest.mark.parametrize('data', [
+    '<blockquote class="twitter-tweet" data-lang="en">\n	&nbsp;</blockquote>',
+    '<blockquote class="twitter-tweet" data-partner="tweetdeck">\n	&nbsp;</blockquote>',
+    '<blockquote class="imgur-embed-pub" data-id="oSDWFTJ" lang="en">\n	&nbsp;</blockquote>',
+    '<blockquote class="twitter-tweet" data-lang="en">&nbsp;</blockquote>',
+    '<blockquote class="twitter-video" data-lang="en">\n	&nbsp;</blockquote>',
+    '<blockquote class="imgur-embed-pub" data-id="a/bMSXD" lang="en">\n	&nbsp;</blockquote>',
+])
+def test_ignore_empty_blocks(data, test_html2ans):
+    assert test_html2ans.generate_ans(data) == []
+
+
 class DummyParser(BaseElementParser):
     applicable_elements = ['foo']
 
@@ -81,3 +102,4 @@ class DummyParserList(BaseElementParser):
             {'type': 'foo', 'bar': "dummy words"},
             {'type': 'foo', 'bar': "others"}
         ], True)
+


### PR DESCRIPTION
## Description (a few sentences describing the overall goals of the PR's commits)
There was an error processing blocks like `<blockquote class="twitter-tweet" data-lang="en">\n	&nbsp;</blockquote>` due to the `&nbsp;` causing issues.

## Steps to Test or Reproduce (outline the steps to test or reproduce the PR here)


## Todos
Before PR:
- [ ] Add tests
- [ ] Add documentation


## Comments (include any comments to help with an effective code review here)

